### PR TITLE
version key required as of HA Core 2021.3

### DIFF
--- a/custom_components/midea_dehumidifier/manifest.json
+++ b/custom_components/midea_dehumidifier/manifest.json
@@ -5,5 +5,6 @@
   "issue_tracker": "https://github.com/barban-dev/homeassistant-midea-dehumidifier/issues",
   "dependencies": [],
   "codeowners": ["@barban-dev"],
-  "requirements": ["midea-inventor-lib==1.0.4"]
+  "requirements": ["midea-inventor-lib==1.0.4"],
+  "version": "1.2.0"
 }


### PR DESCRIPTION
From Home Assistant Core 2021.3 version key is now required for custom components. 

For now, this will create a warning on start-up, but eventually the custom component will be blocked from loading if it’s missing a version in the manifest json file.

See here https://github.com/home-assistant/core/pull/45919