### PR TITLE
Import ATTR_MODE from homeassistant.const instead

### DIFF
--- a/custom_components/midea_dehumidifier/humidifier.py
+++ b/custom_components/midea_dehumidifier/humidifier.py
@@ -8,14 +8,13 @@ VERSION = '1.0.2'
 import logging
 from typing import List, Optional
 from custom_components.midea_dehumidifier import DOMAIN, MIDEA_API_CLIENT, MIDEA_TARGET_DEVICE
-
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_MODE
 from homeassistant.components.humidifier import HumidifierEntity
 from homeassistant.components.humidifier.const import (
     ATTR_AVAILABLE_MODES,
     ATTR_HUMIDITY,
     ATTR_MAX_HUMIDITY,
     ATTR_MIN_HUMIDITY,
-    ATTR_MODE,
     DEFAULT_MAX_HUMIDITY,
     DEFAULT_MIN_HUMIDITY,
     DEVICE_CLASS_DEHUMIDIFIER,

--- a/custom_components/midea_dehumidifier/humidifier.py
+++ b/custom_components/midea_dehumidifier/humidifier.py
@@ -8,7 +8,7 @@ VERSION = '1.0.2'
 import logging
 from typing import List, Optional
 from custom_components.midea_dehumidifier import DOMAIN, MIDEA_API_CLIENT, MIDEA_TARGET_DEVICE
-from homeassistant.const import ATTR_ENTITY_ID, ATTR_MODE
+from homeassistant.const import ATTR_MODE
 from homeassistant.components.humidifier import HumidifierEntity
 from homeassistant.components.humidifier.const import (
     ATTR_AVAILABLE_MODES,
@@ -514,4 +514,3 @@ class MideaDehumidifierDevice(HumidifierEntity):
                 self.__refresh_device_status()
             else:
                 _LOGGER.error("climate.midea-dehumi: send_mode_command ERROR.")
-


### PR DESCRIPTION
Based on [this merged PR](https://github.com/home-assistant/core/pull/46948) as of HA Core 2021.4

homeassistant.components.humidifier.const file was changed and ATTR_MODE was removed. 
This leads to a breaking change as the integration is unable to import it and completely breaks.

ATTR_MODE can be imported from homeassistant.const instead

Fixes #21