### PR TITLE
replace device_state_attributes with extra_state_attributes

### DIFF
--- a/custom_components/midea_dehumidifier/humidifier.py
+++ b/custom_components/midea_dehumidifier/humidifier.py
@@ -269,7 +269,7 @@ class MideaDehumidifierDevice(HumidifierEntity):
         return self._tankShow
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return entity specific state attributes."""
         data = {}
 


### PR DESCRIPTION
`device_state_attributes` is deprecated and replace by `extra_state_attributes` from 2021.12 onwards and functionality will be remove in 2022.4.