### PR TITLE
Stop log spam when an appliance is offline; mark entities unavailable

### DIFF
--- a/custom_components/midea_dehumidifier/__init__.py
+++ b/custom_components/midea_dehumidifier/__init__.py
@@ -24,6 +24,27 @@ _LOGGER = logging.getLogger(__name__)
 CONF_SHA256_PASSWORD = 'sha256password'
 CONF_DEVICEID = 'deviceId'
 
+#midea_inventor_lib logs this on the root logger (bare logging.error) every poll while
+#the appliance is offline, so it can't be silenced via HA's per-namespace logger: config.
+_OFFLINE_NOISE_MARKER = 'MideaClient::send_api_request: errorCode=3123'
+
+
+class _MideaOfflineNoiseFilter(logging.Filter):
+    """Drop the repeated 'appliance is offline' error logged on the root logger."""
+
+    def filter(self, record):
+        try:
+            return _OFFLINE_NOISE_MARKER not in record.getMessage()
+        except Exception:
+            return True
+
+
+def _install_offline_noise_filter():
+    """Add the offline-noise filter to the root logger once."""
+    root = logging.getLogger()
+    if not any(isinstance(f, _MideaOfflineNoiseFilter) for f in root.filters):
+        root.addFilter(_MideaOfflineNoiseFilter())
+
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_USERNAME): cv.string,
@@ -38,6 +59,8 @@ async def async_setup(hass, config):
     """Set up client for Midea API based on configuration entries."""
     _LOGGER.info("midea_dehumidifier: initializing platform...")
     _LOGGER.debug("midea_dehumidifier: starting async_setup")
+
+    _install_offline_noise_filter()
 
     if DOMAIN not in config:
         _LOGGER.error("midea_dehumi: cannot find midea_dehumi platform on configuration.yaml")

--- a/custom_components/midea_dehumidifier/humidifier.py
+++ b/custom_components/midea_dehumidifier/humidifier.py
@@ -171,7 +171,10 @@ class MideaDehumidifierDevice(HumidifierEntity):
         self._dryClothesSetSwitch = None
         self._upanddownSwing = None
         self._tankShow = False
-	    
+
+        #Reachability, updated by async_update()
+        self._available = True
+
         self._device_class = HumidifierDeviceClass.DEHUMIDIFIER
 
         ##Get appliance's status to set initial values for the device
@@ -209,6 +212,11 @@ class MideaDehumidifierDevice(HumidifierEntity):
         """Return the polling state."""
         #get device's status by polling it: Midea Web API lacks of notification capability
         return True
+
+    @property
+    def available(self):
+        """Return True if the appliance is reachable."""
+        return self._available
 
     @property
     def target_humidity(self):
@@ -378,19 +386,36 @@ class MideaDehumidifierDevice(HumidifierEntity):
 
 
     async def async_update(self):
-        """Retrieve latest state from the appliance and keep UI updated with respect to the updated status."""
-        _LOGGER.info("midea-dehumidifier: async_update called.")
-        
-        if self._client.security.access_token:
+        """Retrieve latest state and keep the entity available/unavailable accordingly."""
+        _LOGGER.debug("midea-dehumidifier: async_update called.")
+
+        if not self._client.security.access_token:
+            return
+
+        #Guard the whole read+refresh: the lib raises when the device is offline
+        try:
             _LOGGER.debug("midea-dehumidifier: sending get_device_status via Web API...")
             #res = self._client.get_device_status(self._device['id'])
             res = await self.hass.async_add_executor_job(self._client.get_device_status, self._device['id'])
-            if res == 1:
-                _LOGGER.info(self._device_status.toString())
+            if res == 1 and self._device_status is not None:
+                _LOGGER.debug("midea-dehumidifier: %s", self._device_status.toString())
                 #Refresh device status
                 self.__refresh_device_status()
+                #mark available only after a clean refresh
+                self.__set_available(True)
             else:
-                _LOGGER.error("midea-dehumidifier: get_device_status ERROR.")
+                self.__set_available(False, "get_device_status returned %s" % res)
+        except Exception as err:
+            self.__set_available(False, "get_device_status failed: %s" % err)
+
+
+    def __set_available(self, available, reason=None):
+        """Set reachability, logging only on offline<->online transitions."""
+        if available and not self._available:
+            _LOGGER.info("midea-dehumidifier: device %s is back online.", self._device['id'])
+        elif not available and self._available:
+            _LOGGER.warning("midea-dehumidifier: device %s is unavailable (%s).", self._device['id'], reason)
+        self._available = available
 
 
     def __refresh_device_status(self):

--- a/custom_components/midea_dehumidifier/sensor.py
+++ b/custom_components/midea_dehumidifier/sensor.py
@@ -9,6 +9,7 @@ import logging
 from custom_components.midea_dehumidifier import DOMAIN, MIDEA_TARGET_DEVICE
 from homeassistant.helpers.entity import Entity
 from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.const import STATE_UNAVAILABLE
 from custom_components.midea_dehumidifier.humidifier import ATTR_CURRRENT_HUMIDITY
 
 _LOGGER = logging.getLogger(__name__)
@@ -51,6 +52,8 @@ class MideaDehumidifierSensor(Entity):
         self._humidifier_entity_id = 'humidifier.midea_dehumidifier_' + targetDevice['id']
 
         self._state = None
+        self._available = True
+        #sets _state and _available from the humidifier entity
         self.__updateStateFromHumidifierEntity()
 
 
@@ -58,6 +61,8 @@ class MideaDehumidifierSensor(Entity):
         """Update state from current_humidity attribute of humidifier entity"""
         #hass.states.get is async friendly (ref. https://dev-docs.home-assistant.io/en/master/api/core.html#homeassistant.core.StateMachine)
         state = self._hass.states.get(self._humidifier_entity_id)
+        #follow the humidifier entity's reachability (it owns the device poll)
+        self._available = state is not None and state.state != STATE_UNAVAILABLE
         if state:
             _LOGGER.debug("state.attributes = %s", state.attributes)
         #ATTR_CURRRENT_HUMIDITY attribute may not exist when device is initializing...
@@ -97,6 +102,11 @@ class MideaDehumidifierSensor(Entity):
     def state(self):
         """Return the state of the sensor."""
         return self._state
+
+    @property
+    def available(self):
+        """Return True if the parent humidifier entity is available."""
+        return self._available
 
     async def async_update(self):
         """Update the state from the template."""

--- a/custom_components/midea_dehumidifier/switch.py
+++ b/custom_components/midea_dehumidifier/switch.py
@@ -8,6 +8,7 @@ VERSION = '1.07'
 import logging
 from custom_components.midea_dehumidifier import DOMAIN, MIDEA_API_CLIENT, MIDEA_TARGET_DEVICE
 from homeassistant.components.switch import SwitchEntity
+from homeassistant.const import STATE_UNAVAILABLE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,7 +36,9 @@ class MideaPumpSwitch(SwitchEntity):
         self._device = targetDevice
         self._name = 'midea_dehumidifier_' + targetDevice['id'] + '_pump'
         self._unique_id = 'midea_dehumidifier_' + targetDevice['id'] + '_pump'
+        self._humidifier_entity_id = 'humidifier.midea_dehumidifier_' + targetDevice['id']
         self._is_on = False
+        self._available = True
 
     @property
     def unique_id(self):
@@ -57,8 +60,16 @@ class MideaPumpSwitch(SwitchEntity):
     def should_poll(self):
         return True
 
+    @property
+    def available(self):
+        """Return True if the parent humidifier entity is available."""
+        return self._available
+
     async def async_update(self):
         """Update pump state from device status."""
+        #follow the humidifier entity's reachability (it owns the device poll)
+        state = self._hass.states.get(self._humidifier_entity_id)
+        self._available = state is not None and state.state != STATE_UNAVAILABLE
         ds = self._client.deviceStatus.get(self._device['id'])
         if ds is not None:
             self._is_on = ds.pumpSwitch == 1


### PR DESCRIPTION
### Problem

When a dehumidifier is unplugged or drops off the network, the integration floods `home-assistant.log` — in my case ~5,300 of each of these per day:

```
ERROR [root] MideaClient::send_api_request: errorCode=3123, errorMessage="The appliance is offline"
ERROR [homeassistant.helpers.entity] Update for humidifier.midea_dehumidifier_... fails
```

Two root causes:

1. **The entity never goes `unavailable`.** `async_update()` lets the offline exception propagate, so HA core logs `Update for ... fails` every poll (default 30s), and the UI keeps showing stale state instead of *Unavailable*.
2. **The `errorCode=3123` line can't be silenced via `logger:`.** `midea_inventor_lib` emits it with a bare module-level `logging.error(...)` (the **root** logger), so per-namespace log config can't target it without muting everything.

### Changes

- **`humidifier.py`** — `async_update()` now wraps the status read + refresh in a `try`, adds an `available` property, and logs a **single line on each offline↔online transition** instead of every poll. An offline (or malformed-but-successful) response marks the entity `unavailable` rather than raising.
- **`__init__.py`** — installs a small, idempotent `logging.Filter` on the root logger (once, in `async_setup`) that drops only the repeated `errorCode=3123 "appliance is offline"` line. It's attached to the *logger* (not a handler), so it only affects that library's root-emitted records and leaves all other integrations' logs untouched.
- **`switch.py`, `sensor.py`** — the pump switch and humidity sensor now mirror the humidifier entity's reachability, so they show *Unavailable* while the device is offline instead of a stale last-known value. (Neither makes its own device call, so this is UI consistency only — no logging change.)

### Result

With one dehumidifier unplugged, verified over 5+ poll cycles:

| Log line | Before | After |
|---|---:|---:|
| `errorCode=3123` (root) | ~5,300/day | **0** |
| `Update for ... fails` | ~5,300/day | **0** |
| Offline transition notice | — | **1** (once) |

The entity now correctly shows *Unavailable* while offline and logs a single `device ... is back online.` when it returns.

### Notes

- Behavior is unchanged when the device is online.
- The offline-noise filter has no teardown hook since the component is YAML-only (`async_setup`, no unload path); the lingering filter instance is harmless and idempotent on reload. Happy to revisit if you'd prefer a different approach (e.g. fixing the logging upstream in `midea_inventor_lib`).
